### PR TITLE
Add Tie-breaker logic

### DIFF
--- a/Volcanoes/Game/Board.cs
+++ b/Volcanoes/Game/Board.cs
@@ -298,6 +298,16 @@ namespace Volcano.Game
                     }
                 }
             }
+            if (TentativeWinner != 0)
+            {
+                if (TentativeWinner == 1)
+                {
+                    Winner = Player.One;
+                }
+                else
+                    Winner = Player.Two;
+                WinningPath = PathTentativeWinner;
+            }
         }
 
         /// <summary>

--- a/Volcanoes/Game/Tournament.cs
+++ b/Volcanoes/Game/Tournament.cs
@@ -171,7 +171,7 @@ namespace Volcano.Game
 
             using (StreamWriter w = new StreamWriter(_gameDataFile))
             {
-                w.WriteLine("Player One,Player Two,Winner,Termination,Total Moves,Total Milliseconds,Starting Tile Index,Transcript,Winning Path,WinCondition");
+                w.WriteLine("Player_One,Player_Two,Winner,Termination,Total_Moves,Total_Milliseconds,Starting_Tile_Index,Transcript,Winning_Path,Win_Condition,Seconds_Per_Move");
                 foreach (var result in results)
                 {
                     string gameResult = "Draw";
@@ -213,11 +213,11 @@ namespace Volcano.Game
                     string winCondition = "";
                     if (result.WinCondition == 1)
                     {
-                        winCondition = "TieOnGrowthBetweenWinnersTurns";
+                        winCondition = "Tie-breaker";
                     }
-                    else winCondition = "NormalWin";
+                    else winCondition = "Normal Win (no tie-breaker)";
 
-                    w.WriteLine(result.PlayerOne + "," + result.PlayerTwo + "," + gameResult + "," + result.Termination.ToString() + "," + result.TotalMoves + "," + result.ElapsedMilliseconds + "," + result.FirstTile + "," + transcript + "," + winningPath + "," + winCondition);
+                    w.WriteLine(result.PlayerOne + "," + result.PlayerTwo + "," + gameResult + "," + result.Termination.ToString() + "," + result.TotalMoves + "," + result.ElapsedMilliseconds + "," + result.FirstTile + "," + transcript + "," + winningPath + "," + winCondition + "," + _secondsPerMove);
                 }
             }
 
@@ -333,7 +333,6 @@ namespace Volcano.Game
         public List<Move> Moves { get; set; }
         public List<int> WinningPath { get; set; }
         public int WinCondition { get; set; }
-
         public TournamentResult(VolcanoGame state, string playerOne, string playerTwo, TournamentTerminationType termination, long milliseconds)
         {
             PlayerOne = playerOne;

--- a/Volcanoes/Game/Tournament.cs
+++ b/Volcanoes/Game/Tournament.cs
@@ -376,6 +376,7 @@ namespace Volcano.Game
             }
 
             WinningPath = state?.CurrentState?.WinningPath ?? new List<int>();
+            WinCondition = state?.CurrentState?.WinCondition ?? new int();
         }
 
         public TournamentResult()

--- a/Volcanoes/Game/Tournament.cs
+++ b/Volcanoes/Game/Tournament.cs
@@ -171,7 +171,7 @@ namespace Volcano.Game
 
             using (StreamWriter w = new StreamWriter(_gameDataFile))
             {
-                w.WriteLine("Player One,Player Two,Winner,Termination,Total Moves,Total Milliseconds,Starting Tile Index,Transcript,Winning Path");
+                w.WriteLine("Player One,Player Two,Winner,Termination,Total Moves,Total Milliseconds,Starting Tile Index,Transcript,Winning Path,WinCondition");
                 foreach (var result in results)
                 {
                     string gameResult = "Draw";
@@ -210,7 +210,14 @@ namespace Volcano.Game
                         }
                     }
 
-                    w.WriteLine(result.PlayerOne + "," + result.PlayerTwo + "," + gameResult + "," + result.Termination.ToString() + "," + result.TotalMoves + "," + result.ElapsedMilliseconds + "," + result.FirstTile + "," + transcript + "," + winningPath);
+                    string winCondition = "";
+                    if (result.WinCondition == 1)
+                    {
+                        winCondition = "TieOnGrowthBetweenWinnersTurns";
+                    }
+                    else winCondition = "NormalWin";
+
+                    w.WriteLine(result.PlayerOne + "," + result.PlayerTwo + "," + gameResult + "," + result.Termination.ToString() + "," + result.TotalMoves + "," + result.ElapsedMilliseconds + "," + result.FirstTile + "," + transcript + "," + winningPath + "," + winCondition);
                 }
             }
 
@@ -325,6 +332,7 @@ namespace Volcano.Game
         public long ElapsedMilliseconds { get; set; }
         public List<Move> Moves { get; set; }
         public List<int> WinningPath { get; set; }
+        public int WinCondition { get; set; }
 
         public TournamentResult(VolcanoGame state, string playerOne, string playerTwo, TournamentTerminationType termination, long milliseconds)
         {


### PR DESCRIPTION
tested with this game:
N26 S10 G N39 S25 G S22 S06 G N31 N30 G N30+ S28 G S18 N31 G
...which now shows blue wins (player one). Testing the tournament changes with simulations, but haven't gotten a "TieOnGrowthBetweenWinnersTurns" result yet to confirm it works.